### PR TITLE
hdl/rtl/wrappers: auxiliary clock PLL parameters added

### DIFF
--- a/hdl/rtl/wrappers/afc_base_wrapper_pkg.vhd
+++ b/hdl/rtl/wrappers/afc_base_wrapper_pkg.vhd
@@ -33,6 +33,14 @@ package afc_base_wrappers_pkg is
     g_CLK3_DIVIDE                            : integer := 4;
     g_CLK3_PHASE                             : real    := 0.0;
     g_SYS_CLOCK_FREQ                         : integer := 100000000;
+    -- aux PLL parameters
+    g_AUX_CLKIN_PERIOD                       : real    := 14.400;
+    g_AUX_DIVCLK_DIVIDE                      : integer := 1;
+    g_AUX_CLKBOUT_MULT_F                     : integer := 18;
+    g_AUX_CLK_DIVIDE                         : integer := 10;
+    g_AUX_CLK_PHASE                          : real    := 0.0;
+    g_AUX_CLK_RAW_DIVIDE                     : integer := 18;
+    g_AUX_CLK_RAW_PHASE                      : real    := 0.0;
     -- AFC Si57x parameters
     g_AFC_SI57x_I2C_FREQ                     : integer := 400000;
     -- Whether or not to initialize oscilator with the specified values
@@ -274,6 +282,14 @@ package afc_base_wrappers_pkg is
     g_CLK3_DIVIDE                            : integer := 4;
     g_CLK3_PHASE                             : real    := 0.0;
     g_SYS_CLOCK_FREQ                         : integer := 100000000;
+    -- aux PLL parameters
+    g_AUX_CLKIN_PERIOD                       : real    := 14.400;
+    g_AUX_DIVCLK_DIVIDE                      : integer := 1;
+    g_AUX_CLKBOUT_MULT_F                     : integer := 18;
+    g_AUX_CLK_DIVIDE                         : integer := 10;
+    g_AUX_CLK_PHASE                          : real    := 0.0;
+    g_AUX_CLK_RAW_DIVIDE                     : integer := 18;
+    g_AUX_CLK_RAW_PHASE                      : real    := 0.0;
     -- AFC Si57x parameters
     g_AFC_SI57x_I2C_FREQ                     : integer := 400000;
     -- Whether or not to initialize oscilator with the specified values
@@ -755,6 +771,14 @@ package afc_base_wrappers_pkg is
     g_CLK3_DIVIDE                              : integer := 4;
     g_CLK3_PHASE                               : real    := 0.0;
     g_SYS_CLOCK_FREQ                           : integer := 100000000;
+    -- aux PLL parameters
+    g_AUX_CLKIN_PERIOD                         : real    := 14.400;
+    g_AUX_DIVCLK_DIVIDE                        : integer := 1;
+    g_AUX_CLKBOUT_MULT_F                       : integer := 18;
+    g_AUX_CLK_DIVIDE                           : integer := 10;
+    g_AUX_CLK_PHASE                            : real    := 0.0;
+    g_AUX_CLK_RAW_DIVIDE                       : integer := 18;
+    g_AUX_CLK_RAW_PHASE                        : real    := 0.0;
     -- AFC Si57x parameters
     g_AFC_SI57x_I2C_FREQ                       : integer := 400000;
     -- Whether or not to initialize oscilator with the specified values

--- a/hdl/rtl/wrappers/afcv3_base.vhd
+++ b/hdl/rtl/wrappers/afcv3_base.vhd
@@ -46,6 +46,14 @@ generic (
   g_CLK3_DIVIDE                            : integer := 4;
   g_CLK3_PHASE                             : real    := 0.0;
   g_SYS_CLOCK_FREQ                         : integer := 100000000;
+  -- aux PLL parameters
+  g_AUX_CLKIN_PERIOD                       : real    := 14.400;
+  g_AUX_DIVCLK_DIVIDE                      : integer := 1;
+  g_AUX_CLKBOUT_MULT_F                     : integer := 18;
+  g_AUX_CLK_DIVIDE                         : integer := 10;
+  g_AUX_CLK_PHASE                          : real    := 0.0;
+  g_AUX_CLK_RAW_DIVIDE                     : integer := 18;
+  g_AUX_CLK_RAW_PHASE                      : real    := 0.0;
   -- AFC Si57x parameters
   g_AFC_SI57x_I2C_FREQ                     : integer := 400000;
   -- Whether or not to initialize oscilator with the specified values
@@ -291,6 +299,14 @@ begin
       g_CLK3_DIVIDE                            => g_CLK3_DIVIDE,
       g_CLK3_PHASE                             => g_CLK3_PHASE,
       g_SYS_CLOCK_FREQ                         => g_SYS_CLOCK_FREQ,
+      -- aux PLL parameters
+      g_AUX_CLKIN_PERIOD                       => g_AUX_CLKIN_PERIOD,
+      g_AUX_DIVCLK_DIVIDE                      => g_AUX_DIVCLK_DIVIDE,
+      g_AUX_CLKBOUT_MULT_F                     => g_AUX_CLKBOUT_MULT_F,
+      g_AUX_CLK_DIVIDE                         => g_AUX_CLK_DIVIDE,
+      g_AUX_CLK_PHASE                          => g_AUX_CLK_PHASE,
+      g_AUX_CLK_RAW_DIVIDE                     => g_AUX_CLK_RAW_DIVIDE,
+      g_AUX_CLK_RAW_PHASE                      => g_AUX_CLK_RAW_PHASE,
       -- AFC Si57x parameters
       g_AFC_SI57x_I2C_FREQ                     => g_AFC_SI57x_I2C_FREQ,
       -- Whether or not to initialize oscilator with the specified values

--- a/hdl/rtl/wrappers/afcv3_base_acq.vhd
+++ b/hdl/rtl/wrappers/afcv3_base_acq.vhd
@@ -48,6 +48,14 @@ generic (
   g_CLK3_DIVIDE                              : integer := 4;
   g_CLK3_PHASE                               : real    := 0.0;
   g_SYS_CLOCK_FREQ                           : integer := 100000000;
+  -- aux PLL parameters
+  g_AUX_CLKIN_PERIOD                         : real    := 14.400;
+  g_AUX_DIVCLK_DIVIDE                        : integer := 1;
+  g_AUX_CLKBOUT_MULT_F                       : integer := 18;
+  g_AUX_CLK_DIVIDE                           : integer := 10;
+  g_AUX_CLK_PHASE                            : real    := 0.0;
+  g_AUX_CLK_RAW_DIVIDE                       : integer := 18;
+  g_AUX_CLK_RAW_PHASE                        : real    := 0.0;
   -- AFC Si57x parameters
   g_AFC_SI57x_I2C_FREQ                       : integer := 400000;
   -- Whether or not to initialize oscilator with the specified values
@@ -285,6 +293,14 @@ begin
       g_CLK1_DIVIDE                            => g_CLK1_DIVIDE,
       g_CLK2_DIVIDE                            => g_CLK2_DIVIDE,
       g_SYS_CLOCK_FREQ                         => g_SYS_CLOCK_FREQ,
+      -- aux PLL parameters
+      g_AUX_CLKIN_PERIOD                       => g_AUX_CLKIN_PERIOD,
+      g_AUX_DIVCLK_DIVIDE                      => g_AUX_DIVCLK_DIVIDE,
+      g_AUX_CLKBOUT_MULT_F                     => g_AUX_CLKBOUT_MULT_F,
+      g_AUX_CLK_DIVIDE                         => g_AUX_CLK_DIVIDE,
+      g_AUX_CLK_PHASE                          => g_AUX_CLK_PHASE,
+      g_AUX_CLK_RAW_DIVIDE                     => g_AUX_CLK_RAW_DIVIDE,
+      g_AUX_CLK_RAW_PHASE                      => g_AUX_CLK_RAW_PHASE,
       -- AFC Si57x parameters
       g_AFC_SI57x_I2C_FREQ                     => g_AFC_SI57x_I2C_FREQ,
       -- Whether or not to initialize oscilator with the specified values

--- a/hdl/rtl/wrappers/afcv4_base.vhd
+++ b/hdl/rtl/wrappers/afcv4_base.vhd
@@ -46,6 +46,14 @@ generic (
   g_CLK3_DIVIDE                            : integer := 4;
   g_CLK3_PHASE                             : real    := 0.0;
   g_SYS_CLOCK_FREQ                         : integer := 100000000;
+  -- aux PLL parameters
+  g_AUX_CLKIN_PERIOD                       : real    := 14.400;
+  g_AUX_DIVCLK_DIVIDE                      : integer := 1;
+  g_AUX_CLKBOUT_MULT_F                     : integer := 18;
+  g_AUX_CLK_DIVIDE                         : integer := 10;
+  g_AUX_CLK_PHASE                          : real    := 0.0;
+  g_AUX_CLK_RAW_DIVIDE                     : integer := 18;
+  g_AUX_CLK_RAW_PHASE                      : real    := 0.0;
   -- AFC Si57x parameters
   g_AFC_SI57x_I2C_FREQ                     : integer := 400000;
   -- Whether or not to initialize oscilator with the specified values
@@ -292,6 +300,14 @@ begin
       g_CLK3_DIVIDE                            => g_CLK3_DIVIDE,
       g_CLK3_PHASE                             => g_CLK3_PHASE,
       g_SYS_CLOCK_FREQ                         => g_SYS_CLOCK_FREQ,
+      -- aux PLL parameters
+      g_AUX_CLKIN_PERIOD                       => g_AUX_CLKIN_PERIOD,
+      g_AUX_DIVCLK_DIVIDE                      => g_AUX_DIVCLK_DIVIDE,
+      g_AUX_CLKBOUT_MULT_F                     => g_AUX_CLKBOUT_MULT_F,
+      g_AUX_CLK_DIVIDE                         => g_AUX_CLK_DIVIDE,
+      g_AUX_CLK_PHASE                          => g_AUX_CLK_PHASE,
+      g_AUX_CLK_RAW_DIVIDE                     => g_AUX_CLK_RAW_DIVIDE,
+      g_AUX_CLK_RAW_PHASE                      => g_AUX_CLK_RAW_PHASE,
       -- AFC Si57x parameters
       g_AFC_SI57x_I2C_FREQ                     => g_AFC_SI57x_I2C_FREQ,
       -- Whether or not to initialize oscilator with the specified values

--- a/hdl/rtl/wrappers/afcv4_base_acq.vhd
+++ b/hdl/rtl/wrappers/afcv4_base_acq.vhd
@@ -48,6 +48,14 @@ generic (
   g_CLK3_DIVIDE                              : integer := 4;
   g_CLK3_PHASE                               : real    := 0.0;
   g_SYS_CLOCK_FREQ                           : integer := 100000000;
+  -- aux PLL parameters
+  g_AUX_CLKIN_PERIOD                         : real    := 14.400;
+  g_AUX_DIVCLK_DIVIDE                        : integer := 1;
+  g_AUX_CLKBOUT_MULT_F                       : integer := 18;
+  g_AUX_CLK_DIVIDE                           : integer := 10;
+  g_AUX_CLK_PHASE                            : real    := 0.0;
+  g_AUX_CLK_RAW_DIVIDE                       : integer := 18;
+  g_AUX_CLK_RAW_PHASE                        : real    := 0.0;
   -- AFC Si57x parameters
   g_AFC_SI57x_I2C_FREQ                       : integer := 400000;
   -- Whether or not to initialize oscilator with the specified values
@@ -286,6 +294,14 @@ begin
       g_CLK1_DIVIDE                            => g_CLK1_DIVIDE,
       g_CLK2_DIVIDE                            => g_CLK2_DIVIDE,
       g_SYS_CLOCK_FREQ                         => g_SYS_CLOCK_FREQ,
+      -- aux PLL parameters
+      g_AUX_CLKIN_PERIOD                       => g_AUX_CLKIN_PERIOD,
+      g_AUX_DIVCLK_DIVIDE                      => g_AUX_DIVCLK_DIVIDE,
+      g_AUX_CLKBOUT_MULT_F                     => g_AUX_CLKBOUT_MULT_F,
+      g_AUX_CLK_DIVIDE                         => g_AUX_CLK_DIVIDE,
+      g_AUX_CLK_PHASE                          => g_AUX_CLK_PHASE,
+      g_AUX_CLK_RAW_DIVIDE                     => g_AUX_CLK_RAW_DIVIDE,
+      g_AUX_CLK_RAW_PHASE                      => g_AUX_CLK_RAW_PHASE,
       -- AFC Si57x parameters
       g_AFC_SI57x_I2C_FREQ                     => g_AFC_SI57x_I2C_FREQ,
       -- Whether or not to initialize oscilator with the specified values


### PR DESCRIPTION
PLL aux generics should be exposed in the hdl/rtl/wrappers also.