### PR TITLE
hdl/rtl/wrappers: auxiliary clock PLL parameters added to pkg

### DIFF
--- a/hdl/rtl/wrappers/afc_base_wrapper_pkg.vhd
+++ b/hdl/rtl/wrappers/afc_base_wrapper_pkg.vhd
@@ -532,6 +532,14 @@ package afc_base_wrappers_pkg is
     g_CLK3_DIVIDE                              : integer := 4;
     g_CLK3_PHASE                               : real    := 0.0;
     g_SYS_CLOCK_FREQ                           : integer := 100000000;
+    -- aux PLL parameters
+    g_AUX_CLKIN_PERIOD                       : real    := 14.400;
+    g_AUX_DIVCLK_DIVIDE                      : integer := 1;
+    g_AUX_CLKBOUT_MULT_F                     : integer := 18;
+    g_AUX_CLK_DIVIDE                         : integer := 10;
+    g_AUX_CLK_PHASE                          : real    := 0.0;
+    g_AUX_CLK_RAW_DIVIDE                     : integer := 18;
+    g_AUX_CLK_RAW_PHASE                      : real    := 0.0;
     -- AFC Si57x parameters
     g_AFC_SI57x_I2C_FREQ                       : integer := 400000;
     -- Whether or not to initialize oscilator with the specified values


### PR DESCRIPTION
Expose the auxiliary clock PLL parameters from afcv3_base_acq
through generics in afc_base_wrapper_pkg