### PR TITLE
Remove wb_afc_diag

### DIFF
--- a/hdl/rtl/base/afc_base_pkg.vhd
+++ b/hdl/rtl/base/afc_base_pkg.vhd
@@ -57,10 +57,9 @@ package afc_base_pkg is
     g_AFC_SI57x_INIT_RFREQ_VALUE             : std_logic_vector(37 downto 0) := "00" & x"3017a66ad";
     g_AFC_SI57x_INIT_N1_VALUE                : std_logic_vector(6 downto 0) := "0000011";
     g_AFC_SI57x_INIT_HS_VALUE                : std_logic_vector(2 downto 0) := "111";
-    --  If true, instantiate a VIC/UART/DIAG/SPI.
+    --  If true, instantiate a VIC/UART/SPI.
     g_WITH_VIC                               : boolean := true;
     g_WITH_UART_MASTER                       : boolean := true;
-    g_WITH_DIAG                              : boolean := true;
     g_WITH_TRIGGER                           : boolean := true;
     g_WITH_SPI                               : boolean := true;
     g_WITH_AFC_SI57x                         : boolean := true;

--- a/hdl/rtl/base_acq/afc_base_acq.vhd
+++ b/hdl/rtl/base_acq/afc_base_acq.vhd
@@ -74,10 +74,9 @@ generic (
   g_AFC_SI57x_INIT_RFREQ_VALUE               : std_logic_vector(37 downto 0) := "00" & x"3017a66ad";
   g_AFC_SI57x_INIT_N1_VALUE                  : std_logic_vector(6 downto 0) := "0000011";
   g_AFC_SI57x_INIT_HS_VALUE                  : std_logic_vector(2 downto 0) := "111";
-  --  If true, instantiate a VIC/UART/DIAG/SPI.
+  --  If true, instantiate a VIC/UART/SPI.
   g_WITH_VIC                                 : boolean := true;
   g_WITH_UART_MASTER                         : boolean := true;
-  g_WITH_DIAG                                : boolean := true;
   g_WITH_TRIGGER                             : boolean := true;
   g_WITH_SPI                                 : boolean := false;
   g_WITH_AFC_SI57x                           : boolean := true;
@@ -455,10 +454,9 @@ begin
       g_AFC_SI57x_INIT_RFREQ_VALUE             => g_AFC_SI57x_INIT_RFREQ_VALUE,
       g_AFC_SI57x_INIT_N1_VALUE                => g_AFC_SI57x_INIT_N1_VALUE,
       g_AFC_SI57x_INIT_HS_VALUE                => g_AFC_SI57x_INIT_HS_VALUE,
-      --  If true, instantiate a VIC/UART/DIAG/SPI.
+      --  If true, instantiate a VIC/UART/SPI.
       g_WITH_VIC                               => g_WITH_VIC,
       g_WITH_UART_MASTER                       => g_WITH_UART_MASTER,
-      g_WITH_DIAG                              => g_WITH_DIAG,
       g_WITH_TRIGGER                           => g_WITH_TRIGGER,
       g_WITH_SPI                               => g_WITH_SPI,
       g_WITH_AFC_SI57x                         => g_WITH_AFC_SI57x,

--- a/hdl/rtl/base_acq/afc_base_acq_pkg.vhd
+++ b/hdl/rtl/base_acq/afc_base_acq_pkg.vhd
@@ -78,10 +78,9 @@ package afc_base_acq_pkg is
     g_AFC_SI57x_INIT_RFREQ_VALUE               : std_logic_vector(37 downto 0) := "00" & x"3017a66ad";
     g_AFC_SI57x_INIT_N1_VALUE                  : std_logic_vector(6 downto 0) := "0000011";
     g_AFC_SI57x_INIT_HS_VALUE                  : std_logic_vector(2 downto 0) := "111";
-    --  If true, instantiate a VIC/UART/DIAG/SPI.
+    --  If true, instantiate a VIC/UART/SPI.
     g_WITH_VIC                                 : boolean := true;
     g_WITH_UART_MASTER                         : boolean := true;
-    g_WITH_DIAG                                : boolean := true;
     g_WITH_TRIGGER                             : boolean := true;
     g_WITH_SPI                                 : boolean := false;
     g_WITH_AFC_SI57x                           : boolean := true;

--- a/hdl/rtl/wrappers/afc_base_wrapper_pkg.vhd
+++ b/hdl/rtl/wrappers/afc_base_wrapper_pkg.vhd
@@ -49,10 +49,9 @@ package afc_base_wrappers_pkg is
     g_AFC_SI57x_INIT_RFREQ_VALUE             : std_logic_vector(37 downto 0) := "00" & x"3017a66ad";
     g_AFC_SI57x_INIT_N1_VALUE                : std_logic_vector(6 downto 0) := "0000011";
     g_AFC_SI57x_INIT_HS_VALUE                : std_logic_vector(2 downto 0) := "111";
-    --  If true, instantiate a VIC/UART/DIAG/SPI.
+    --  If true, instantiate a VIC/UART/SPI.
     g_WITH_VIC                               : boolean := true;
     g_WITH_UART_MASTER                       : boolean := true;
-    g_WITH_DIAG                              : boolean := true;
     g_WITH_TRIGGER                           : boolean := true;
     g_WITH_SPI                               : boolean := true;
     g_WITH_AFC_SI57x                         : boolean := true;
@@ -298,10 +297,9 @@ package afc_base_wrappers_pkg is
     g_AFC_SI57x_INIT_RFREQ_VALUE             : std_logic_vector(37 downto 0) := "00" & x"3017a66ad";
     g_AFC_SI57x_INIT_N1_VALUE                : std_logic_vector(6 downto 0) := "0000011";
     g_AFC_SI57x_INIT_HS_VALUE                : std_logic_vector(2 downto 0) := "111";
-    --  If true, instantiate a VIC/UART/DIAG/SPI.
+    --  If true, instantiate a VIC/UART/SPI.
     g_WITH_VIC                               : boolean := true;
     g_WITH_UART_MASTER                       : boolean := true;
-    g_WITH_DIAG                              : boolean := true;
     g_WITH_TRIGGER                           : boolean := true;
     g_WITH_SPI                               : boolean := true;
     g_WITH_AFC_SI57x                         : boolean := true;
@@ -548,10 +546,9 @@ package afc_base_wrappers_pkg is
     g_AFC_SI57x_INIT_RFREQ_VALUE               : std_logic_vector(37 downto 0) := "00" & x"3017a66ad";
     g_AFC_SI57x_INIT_N1_VALUE                  : std_logic_vector(6 downto 0) := "0000011";
     g_AFC_SI57x_INIT_HS_VALUE                  : std_logic_vector(2 downto 0) := "111";
-    --  If true, instantiate a VIC/UART/DIAG/SPI.
+    --  If true, instantiate a VIC/UART/SPI.
     g_WITH_VIC                                 : boolean := true;
     g_WITH_UART_MASTER                         : boolean := true;
-    g_WITH_DIAG                                : boolean := true;
     g_WITH_TRIGGER                             : boolean := true;
     g_WITH_SPI                                 : boolean := false;
     g_WITH_AFC_SI57x                           : boolean := true;
@@ -795,10 +792,9 @@ package afc_base_wrappers_pkg is
     g_AFC_SI57x_INIT_RFREQ_VALUE               : std_logic_vector(37 downto 0) := "00" & x"3017a66ad";
     g_AFC_SI57x_INIT_N1_VALUE                  : std_logic_vector(6 downto 0) := "0000011";
     g_AFC_SI57x_INIT_HS_VALUE                  : std_logic_vector(2 downto 0) := "111";
-    --  If true, instantiate a VIC/UART/DIAG/SPI.
+    --  If true, instantiate a VIC/UART/SPI.
     g_WITH_VIC                                 : boolean := true;
     g_WITH_UART_MASTER                         : boolean := true;
-    g_WITH_DIAG                                : boolean := true;
     g_WITH_TRIGGER                             : boolean := true;
     g_WITH_SPI                                 : boolean := false;
     g_WITH_AFC_SI57x                           : boolean := true;

--- a/hdl/rtl/wrappers/afcv3_base.vhd
+++ b/hdl/rtl/wrappers/afcv3_base.vhd
@@ -62,10 +62,9 @@ generic (
   g_AFC_SI57x_INIT_RFREQ_VALUE             : std_logic_vector(37 downto 0) := "00" & x"3017a66ad";
   g_AFC_SI57x_INIT_N1_VALUE                : std_logic_vector(6 downto 0) := "0000011";
   g_AFC_SI57x_INIT_HS_VALUE                : std_logic_vector(2 downto 0) := "111";
-  --  If true, instantiate a VIC/UART/DIAG/SPI.
+  --  If true, instantiate a VIC/UART/SPI.
   g_WITH_VIC                               : boolean := true;
   g_WITH_UART_MASTER                       : boolean := true;
-  g_WITH_DIAG                              : boolean := true;
   g_WITH_TRIGGER                           : boolean := true;
   g_WITH_SPI                               : boolean := true;
   g_WITH_AFC_SI57x                         : boolean := true;
@@ -315,10 +314,9 @@ begin
       g_AFC_SI57x_INIT_RFREQ_VALUE             => g_AFC_SI57x_INIT_RFREQ_VALUE,
       g_AFC_SI57x_INIT_N1_VALUE                => g_AFC_SI57x_INIT_N1_VALUE,
       g_AFC_SI57x_INIT_HS_VALUE                => g_AFC_SI57x_INIT_HS_VALUE,
-      --  If true, instantiate a VIC/UART/DIAG/SPI.
+      --  If true, instantiate a VIC/UART/SPI.
       g_WITH_VIC                               => g_WITH_VIC,
       g_WITH_UART_MASTER                       => g_WITH_UART_MASTER,
-      g_WITH_DIAG                              => g_WITH_DIAG,
       g_WITH_TRIGGER                           => g_WITH_TRIGGER,
       g_WITH_SPI                               => g_WITH_SPI,
       g_WITH_AFC_SI57x                         => g_WITH_AFC_SI57x,

--- a/hdl/rtl/wrappers/afcv3_base_acq.vhd
+++ b/hdl/rtl/wrappers/afcv3_base_acq.vhd
@@ -64,10 +64,9 @@ generic (
   g_AFC_SI57x_INIT_RFREQ_VALUE               : std_logic_vector(37 downto 0) := "00" & x"3017a66ad";
   g_AFC_SI57x_INIT_N1_VALUE                  : std_logic_vector(6 downto 0) := "0000011";
   g_AFC_SI57x_INIT_HS_VALUE                  : std_logic_vector(2 downto 0) := "111";
-  --  If true, instantiate a VIC/UART/DIAG/SPI.
+  --  If true, instantiate a VIC/UART/SPI.
   g_WITH_VIC                                 : boolean := true;
   g_WITH_UART_MASTER                         : boolean := true;
-  g_WITH_DIAG                                : boolean := true;
   g_WITH_TRIGGER                             : boolean := true;
   g_WITH_SPI                                 : boolean := false;
   g_WITH_AFC_SI57x                           : boolean := true;
@@ -309,10 +308,9 @@ begin
       g_AFC_SI57x_INIT_RFREQ_VALUE             => g_AFC_SI57x_INIT_RFREQ_VALUE,
       g_AFC_SI57x_INIT_N1_VALUE                => g_AFC_SI57x_INIT_N1_VALUE,
       g_AFC_SI57x_INIT_HS_VALUE                => g_AFC_SI57x_INIT_HS_VALUE,
-      --  If true, instantiate a VIC/UART/DIAG/SPI.
+      --  If true, instantiate a VIC/UART/SPI.
       g_WITH_VIC                               => g_WITH_VIC,
       g_WITH_UART_MASTER                       => g_WITH_UART_MASTER,
-      g_WITH_DIAG                              => g_WITH_DIAG,
       g_WITH_TRIGGER                           => g_WITH_TRIGGER,
       g_WITH_SPI                               => g_WITH_SPI,
       g_WITH_AFC_SI57x                         => g_WITH_AFC_SI57x,

--- a/hdl/rtl/wrappers/afcv4_base.vhd
+++ b/hdl/rtl/wrappers/afcv4_base.vhd
@@ -62,10 +62,9 @@ generic (
   g_AFC_SI57x_INIT_RFREQ_VALUE             : std_logic_vector(37 downto 0) := "00" & x"3017a66ad";
   g_AFC_SI57x_INIT_N1_VALUE                : std_logic_vector(6 downto 0) := "0000011";
   g_AFC_SI57x_INIT_HS_VALUE                : std_logic_vector(2 downto 0) := "111";
-  --  If true, instantiate a VIC/UART/DIAG/SPI.
+  --  If true, instantiate a VIC/UART/SPI.
   g_WITH_VIC                               : boolean := true;
   g_WITH_UART_MASTER                       : boolean := true;
-  g_WITH_DIAG                              : boolean := true;
   g_WITH_TRIGGER                           : boolean := true;
   g_WITH_SPI                               : boolean := true;
   g_WITH_AFC_SI57x                         : boolean := true;
@@ -316,10 +315,9 @@ begin
       g_AFC_SI57x_INIT_RFREQ_VALUE             => g_AFC_SI57x_INIT_RFREQ_VALUE,
       g_AFC_SI57x_INIT_N1_VALUE                => g_AFC_SI57x_INIT_N1_VALUE,
       g_AFC_SI57x_INIT_HS_VALUE                => g_AFC_SI57x_INIT_HS_VALUE,
-      --  If true, instantiate a VIC/UART/DIAG/SPI.
+      --  If true, instantiate a VIC/UART/SPI.
       g_WITH_VIC                               => g_WITH_VIC,
       g_WITH_UART_MASTER                       => g_WITH_UART_MASTER,
-      g_WITH_DIAG                              => g_WITH_DIAG,
       g_WITH_TRIGGER                           => g_WITH_TRIGGER,
       g_WITH_SPI                               => g_WITH_SPI,
       g_WITH_AFC_SI57x                         => g_WITH_AFC_SI57x,

--- a/hdl/rtl/wrappers/afcv4_base_acq.vhd
+++ b/hdl/rtl/wrappers/afcv4_base_acq.vhd
@@ -64,10 +64,9 @@ generic (
   g_AFC_SI57x_INIT_RFREQ_VALUE               : std_logic_vector(37 downto 0) := "00" & x"3017a66ad";
   g_AFC_SI57x_INIT_N1_VALUE                  : std_logic_vector(6 downto 0) := "0000011";
   g_AFC_SI57x_INIT_HS_VALUE                  : std_logic_vector(2 downto 0) := "111";
-  --  If true, instantiate a VIC/UART/DIAG/SPI.
+  --  If true, instantiate a VIC/UART/SPI.
   g_WITH_VIC                                 : boolean := true;
   g_WITH_UART_MASTER                         : boolean := true;
-  g_WITH_DIAG                                : boolean := true;
   g_WITH_TRIGGER                             : boolean := true;
   g_WITH_SPI                                 : boolean := false;
   g_WITH_AFC_SI57x                           : boolean := true;
@@ -310,10 +309,9 @@ begin
       g_AFC_SI57x_INIT_RFREQ_VALUE             => g_AFC_SI57x_INIT_RFREQ_VALUE,
       g_AFC_SI57x_INIT_N1_VALUE                => g_AFC_SI57x_INIT_N1_VALUE,
       g_AFC_SI57x_INIT_HS_VALUE                => g_AFC_SI57x_INIT_HS_VALUE,
-      --  If true, instantiate a VIC/UART/DIAG/SPI.
+      --  If true, instantiate a VIC/UART/SPI.
       g_WITH_VIC                               => g_WITH_VIC,
       g_WITH_UART_MASTER                       => g_WITH_UART_MASTER,
-      g_WITH_DIAG                              => g_WITH_DIAG,
       g_WITH_TRIGGER                           => g_WITH_TRIGGER,
       g_WITH_SPI                               => g_WITH_SPI,
       g_WITH_AFC_SI57x                         => g_WITH_AFC_SI57x,

--- a/hdl/top/afc_v3/vivado/acq/afc_acq.vhd
+++ b/hdl/top/afc_v3/vivado/acq/afc_acq.vhd
@@ -298,10 +298,9 @@ begin
 
   cmp_afc_base_acq : afc_base_acq
     generic map (
-      --  If true, instantiate a VIC/UART/DIAG/SPI.
+      --  If true, instantiate a VIC/UART/SPI.
       g_WITH_VIC                               => true,
       g_WITH_UART_MASTER                       => true,
-      g_WITH_DIAG                              => true,
       g_WITH_TRIGGER                           => true,
       g_WITH_SPI                               => false,
       g_WITH_BOARD_I2C                         => true,

--- a/hdl/top/afc_v3/vivado/full/afc_full.vhd
+++ b/hdl/top/afc_v3/vivado/full/afc_full.vhd
@@ -206,10 +206,9 @@ begin
 
   cmp_afc_base : afc_base
     generic map (
-      --  If true, instantiate a VIC/UART/DIAG/SPI.
+      --  If true, instantiate a VIC/UART/SPI.
       g_WITH_VIC                               => true,
       g_WITH_UART_MASTER                       => true,
-      g_WITH_DIAG                              => true,
       g_WITH_TRIGGER                           => true,
       g_WITH_SPI                               => false,
       g_WITH_BOARD_I2C                         => true,

--- a/hdl/top/afc_v3/vivado/pcie_leds/pcie_leds.vhd
+++ b/hdl/top/afc_v3/vivado/pcie_leds/pcie_leds.vhd
@@ -81,6 +81,13 @@ port(
   pcie_clk_p_i                             : in std_logic;
   pcie_clk_n_i                             : in std_logic;
 
+  -- Si57x oscillator
+  afc_si57x_scl_b                            : inout std_logic;
+  afc_si57x_sda_b                            : inout std_logic;
+
+  -- Si57x oscillator output enable
+  afc_si57x_oe_o                             : out   std_logic;
+
   -----------------------------------------
   -- User LEDs
   -----------------------------------------
@@ -138,17 +145,29 @@ architecture rtl of pcie_leds is
   signal app_wb_out                        : t_wishbone_master_out;
   signal app_wb_in                         : t_wishbone_master_in := c_DUMMY_WB_MASTER_IN;
 
+  constant c_AFC_SI57x_I2C_FREQ              : natural := 400000;
+  constant c_AFC_SI57x_INIT_OSC              : boolean := true;
+  constant c_AFC_SI57x_INIT_RFREQ_VALUE      : std_logic_vector(37 downto 0) := "00" & x"309c85ab2";
+  constant c_AFC_SI57x_INIT_N1_VALUE         : std_logic_vector(6 downto 0) := "0010011";
+  constant c_AFC_SI57x_INIT_HS_VALUE         : std_logic_vector(2 downto 0) := "000";
+
 begin
 
   cmp_afc_base : afc_base
     generic map (
-      --  If true, instantiate a VIC/UART/DIAG/SPI.
+      --  If true, instantiate a VIC/UART/SPI.
       g_WITH_VIC                               => false,
       g_WITH_UART_MASTER                       => false,
-      g_WITH_DIAG                              => false,
       g_WITH_TRIGGER                           => false,
       g_WITH_SPI                               => false,
       g_WITH_BOARD_I2C                         => false,
+      g_AFC_SI57x_I2C_FREQ                     => c_AFC_SI57x_I2C_FREQ,
+      -- Whether or not to initialize oscilator with the specified values
+      g_AFC_SI57x_INIT_OSC                     => c_AFC_SI57x_INIT_OSC,
+      -- Init Oscillator values
+      g_AFC_SI57x_INIT_RFREQ_VALUE             => c_AFC_SI57x_INIT_RFREQ_VALUE,
+      g_AFC_SI57x_INIT_N1_VALUE                => c_AFC_SI57x_INIT_N1_VALUE,
+      g_AFC_SI57x_INIT_HS_VALUE                => c_AFC_SI57x_INIT_HS_VALUE,
       -- Auxiliary clock used to sync incoming triggers in the trigger module.
       -- If false, trigger will be synch'ed with clk_sys
       g_WITH_AUX_CLK                           => false,
@@ -206,6 +225,16 @@ begin
       -- PCI clock and reset signals
       pcie_clk_p_i                             => pcie_clk_p_i,
       pcie_clk_n_i                             => pcie_clk_n_i,
+
+      ---------------------------------------------------------------------------
+      -- AFC I2C.
+      ---------------------------------------------------------------------------
+      -- Si57x oscillator
+      afc_si57x_scl_b                          => afc_si57x_scl_b,
+      afc_si57x_sda_b                          => afc_si57x_sda_b,
+
+      -- Si57x oscillator output enable
+      afc_si57x_oe_o                           => afc_si57x_oe_o,
 
       ---------------------------------------------------------------------------
       -- User LEDs


### PR DESCRIPTION
The wb_afc_diag is not needed anymore and doesn't work with newer OpenMMC releases. This core was written a long time ago and doesn't follow the conventions we adopted.