### PR TITLE
scripts/si57-clk-calc.py: fix best frequency match.

### DIFF
--- a/scripts/si57-clk-calc.py
+++ b/scripts/si57-clk-calc.py
@@ -70,6 +70,7 @@ def si570_calc_divs(fout, fxtal):
             else:
                 freq_err_now = abs(fout - (fdco / (hsdiv * n1)))
                 if (freq_err_now < freq_err_best):
+                    freq_err_best = freq_err_now
                     rfreq_best = rfreq
                     hsdiv_best = hsdiv
                     n1_best = n1


### PR DESCRIPTION
freq_err_best wasn't being updated, so the value returned by the function was the last coefficient combination to have an error less than 1MHz.

I haven't tested if the values returned by this function work to sync the clock yet.