### PR TITLE
Add g_BENCH_MODE generic flag

### DIFF
--- a/hdl/rtl/base/afc_base.vhd
+++ b/hdl/rtl/base/afc_base.vhd
@@ -46,6 +46,9 @@ use work.afc_base_pkg.all;
 
 entity afc_base is
 generic (
+  -- Bench mode, prevents PCIe reseting devices sharing the
+  -- rst_sys_n_o reset signal
+  g_BENCH_MODE                             : boolean := false;
   -- system PLL parameters
   g_DIVCLK_DIVIDE                          : integer := 5;
   g_CLKBOUT_MULT_F                         : integer := 48;
@@ -719,7 +722,7 @@ begin
   clk_sys_pcie_rst                           <= not clk_sys_pcie_rstn;
   -- Reset for all other modules
   clk_sys_rstn_raw                           <= reset_rstn(c_clk_sys_id) and rst_button_sys_n and
-                                                   uart_rstn and wb_ma_pcie_rstn_sync;
+                                                   uart_rstn and '1' when g_BENCH_MODE else wb_ma_pcie_rstn_sync;
   clk_sys_rst_raw                            <= not clk_sys_rstn_raw;
 
   -- Additional stage for clk_sys reset as we AND other resets that might fail

--- a/hdl/rtl/base/afc_base_pkg.vhd
+++ b/hdl/rtl/base/afc_base_pkg.vhd
@@ -29,6 +29,9 @@ package afc_base_pkg is
   --------------------------------------------------------------------
   component afc_base
   generic (
+    -- Bench mode, prevents PCIe reseting devices sharing the
+    -- rst_sys_n_o reset signal
+    g_BENCH_MODE                             : boolean := false;
     -- system PLL parameters
     g_DIVCLK_DIVIDE                          : integer := 5;
     g_CLKBOUT_MULT_F                         : integer := 48;

--- a/hdl/rtl/base_acq/afc_base_acq.vhd
+++ b/hdl/rtl/base_acq/afc_base_acq.vhd
@@ -46,6 +46,9 @@ use work.pcie_cntr_axi_pkg.all;
 
 entity afc_base_acq is
 generic (
+  -- Bench mode, prevents PCIe reseting devices sharing the
+  -- rst_sys_n_o reset signal
+  g_BENCH_MODE                               : boolean := false;
   -- system PLL parameters
   g_DIVCLK_DIVIDE                            : integer := 5;
   g_CLKBOUT_MULT_F                           : integer := 48;
@@ -426,6 +429,7 @@ begin
 
   cmp_afc_base : afc_base
     generic map (
+      g_BENCH_MODE                             => g_BENCH_MODE,
       -- system PLL parameters
       g_DIVCLK_DIVIDE                          => g_DIVCLK_DIVIDE,
       g_CLKBOUT_MULT_F                         => g_CLKBOUT_MULT_F,

--- a/hdl/rtl/base_acq/afc_base_acq_pkg.vhd
+++ b/hdl/rtl/base_acq/afc_base_acq_pkg.vhd
@@ -50,6 +50,9 @@ package afc_base_acq_pkg is
   --------------------------------------------------------------------
   component afc_base_acq
   generic (
+    -- Bench mode, prevents PCIe reseting devices sharing the
+    -- rst_sys_n_o reset signal
+    g_BENCH_MODE                               : boolean := false;
     -- system PLL parameters
     g_DIVCLK_DIVIDE                            : integer := 5;
     g_CLKBOUT_MULT_F                           : integer := 48;

--- a/hdl/rtl/wrappers/afc_base_wrapper_pkg.vhd
+++ b/hdl/rtl/wrappers/afc_base_wrapper_pkg.vhd
@@ -21,6 +21,9 @@ package afc_base_wrappers_pkg is
 
   component afcv3_base
   generic (
+    -- Bench mode, prevents PCIe reseting devices sharing the
+    -- rst_sys_n_o reset signal
+    g_BENCH_MODE                             : boolean := false;
     -- system PLL parameters
     g_DIVCLK_DIVIDE                          : integer := 5;
     g_CLKBOUT_MULT_F                         : integer := 48;
@@ -269,6 +272,9 @@ package afc_base_wrappers_pkg is
 
   component afcv4_base
   generic (
+    -- Bench mode, prevents PCIe reseting devices sharing the
+    -- rst_sys_n_o reset signal
+    g_BENCH_MODE                             : boolean := false;
     -- system PLL parameters
     g_DIVCLK_DIVIDE                          : integer := 5;
     g_CLKBOUT_MULT_F                         : integer := 48;
@@ -518,6 +524,9 @@ package afc_base_wrappers_pkg is
 
   component afcv3_base_acq
   generic (
+    -- Bench mode, prevents PCIe reseting devices sharing the
+    -- rst_sys_n_o reset signal
+    g_BENCH_MODE                             : boolean := false;
     -- system PLL parameters
     g_DIVCLK_DIVIDE                            : integer := 5;
     g_CLKBOUT_MULT_F                           : integer := 48;
@@ -764,6 +773,9 @@ package afc_base_wrappers_pkg is
 
   component afcv4_base_acq
   generic (
+    -- Bench mode, prevents PCIe reseting devices sharing the
+    -- rst_sys_n_o reset signal
+    g_BENCH_MODE                               : boolean := false;
     -- system PLL parameters
     g_DIVCLK_DIVIDE                            : integer := 5;
     g_CLKBOUT_MULT_F                           : integer := 48;

--- a/hdl/rtl/wrappers/afcv3_base.vhd
+++ b/hdl/rtl/wrappers/afcv3_base.vhd
@@ -34,6 +34,9 @@ use work.pcie_cntr_axi_pkg.all;
 
 entity afcv3_base is
 generic (
+  -- Bench mode, prevents PCIe reseting devices sharing the
+  -- rst_sys_n_o reset signal
+  g_BENCH_MODE                             : boolean := false;
   -- system PLL parameters
   g_DIVCLK_DIVIDE                          : integer := 5;
   g_CLKBOUT_MULT_F                         : integer := 48;
@@ -286,6 +289,7 @@ begin
 
   cmp_afc_base : afc_base
     generic map (
+      g_BENCH_MODE                             => g_BENCH_MODE,
       -- system PLL parameters
       g_DIVCLK_DIVIDE                          => g_DIVCLK_DIVIDE,
       g_CLKBOUT_MULT_F                         => g_CLKBOUT_MULT_F,

--- a/hdl/rtl/wrappers/afcv3_base_acq.vhd
+++ b/hdl/rtl/wrappers/afcv3_base_acq.vhd
@@ -36,6 +36,9 @@ use work.afc_base_acq_pkg.all;
 
 entity afcv3_base_acq is
 generic (
+  -- Bench mode, prevents PCIe reseting devices sharing the
+  -- rst_sys_n_o reset signal
+  g_BENCH_MODE                               : boolean := false;
   -- system PLL parameters
   g_DIVCLK_DIVIDE                            : integer := 5;
   g_CLKBOUT_MULT_F                           : integer := 48;
@@ -286,6 +289,7 @@ begin
 
   cmp_afc_base_acq : afc_base_acq
     generic map (
+      g_BENCH_MODE                             => g_BENCH_MODE,
       g_DIVCLK_DIVIDE                          => g_DIVCLK_DIVIDE,
       g_CLKBOUT_MULT_F                         => g_CLKBOUT_MULT_F,
       g_CLK0_DIVIDE_F                          => g_CLK0_DIVIDE_F,

--- a/hdl/rtl/wrappers/afcv4_base.vhd
+++ b/hdl/rtl/wrappers/afcv4_base.vhd
@@ -34,6 +34,9 @@ use work.pcie_cntr_axi_pkg.all;
 
 entity afcv4_base is
 generic (
+  -- Bench mode, prevents PCIe reseting devices sharing the
+  -- rst_sys_n_o reset signal
+  g_BENCH_MODE                             : boolean := false;
   -- system PLL parameters
   g_DIVCLK_DIVIDE                          : integer := 5;
   g_CLKBOUT_MULT_F                         : integer := 48;
@@ -287,6 +290,7 @@ begin
 
   cmp_afc_base : afc_base
     generic map (
+      g_BENCH_MODE                             => g_BENCH_MODE,
       -- system PLL parameters
       g_DIVCLK_DIVIDE                          => g_DIVCLK_DIVIDE,
       g_CLKBOUT_MULT_F                         => g_CLKBOUT_MULT_F,

--- a/hdl/rtl/wrappers/afcv4_base_acq.vhd
+++ b/hdl/rtl/wrappers/afcv4_base_acq.vhd
@@ -36,6 +36,9 @@ use work.afc_base_acq_pkg.all;
 
 entity afcv4_base_acq is
 generic (
+  -- Bench mode, prevents PCIe reseting devices sharing the
+  -- rst_sys_n_o reset signal
+  g_BENCH_MODE                               : boolean := false;
   -- system PLL parameters
   g_DIVCLK_DIVIDE                            : integer := 5;
   g_CLKBOUT_MULT_F                           : integer := 48;
@@ -287,6 +290,7 @@ begin
 
   cmp_afc_base_acq : afc_base_acq
     generic map (
+      g_BENCH_MODE                             => g_BENCH_MODE,
       g_DIVCLK_DIVIDE                          => g_DIVCLK_DIVIDE,
       g_CLKBOUT_MULT_F                         => g_CLKBOUT_MULT_F,
       g_CLK0_DIVIDE_F                          => g_CLK0_DIVIDE_F,

--- a/hdl/top/afc_v3/vivado/acq/afc_acq.vhd
+++ b/hdl/top/afc_v3/vivado/acq/afc_acq.vhd
@@ -298,6 +298,7 @@ begin
 
   cmp_afc_base_acq : afc_base_acq
     generic map (
+      g_BENCH_MODE                             => false,
       --  If true, instantiate a VIC/UART/SPI.
       g_WITH_VIC                               => true,
       g_WITH_UART_MASTER                       => true,

--- a/hdl/top/afc_v3/vivado/full/afc_full.vhd
+++ b/hdl/top/afc_v3/vivado/full/afc_full.vhd
@@ -206,6 +206,7 @@ begin
 
   cmp_afc_base : afc_base
     generic map (
+      g_BENCH_MODE                             => false,
       --  If true, instantiate a VIC/UART/SPI.
       g_WITH_VIC                               => true,
       g_WITH_UART_MASTER                       => true,

--- a/hdl/top/afc_v3/vivado/pcie_leds/pcie_leds.vhd
+++ b/hdl/top/afc_v3/vivado/pcie_leds/pcie_leds.vhd
@@ -155,6 +155,7 @@ begin
 
   cmp_afc_base : afc_base
     generic map (
+      g_BENCH_MODE                             => false,
       --  If true, instantiate a VIC/UART/SPI.
       g_WITH_VIC                               => false,
       g_WITH_UART_MASTER                       => false,


### PR DESCRIPTION
This generic makes possible to test the board when there is no PCIe link up (i.e. it ignores the PCIe reset signal).