### PR TITLE
Write and read from wishbone via UART (new implementation)

### DIFF
--- a/hdl/rtl/base/afc_base.vhd
+++ b/hdl/rtl/base/afc_base.vhd
@@ -46,6 +46,9 @@ use work.afc_base_pkg.all;
 
 entity afc_base is
 generic (
+  -- Bench mode, prevents PCIe reseting devices sharing the
+  -- rst_sys_n_o reset signal
+  g_BENCH_MODE                             : boolean := false;
   -- system PLL parameters
   g_DIVCLK_DIVIDE                          : integer := 5;
   g_CLKBOUT_MULT_F                         : integer := 48;
@@ -719,7 +722,7 @@ begin
   clk_sys_pcie_rst                           <= not clk_sys_pcie_rstn;
   -- Reset for all other modules
   clk_sys_rstn_raw                           <= reset_rstn(c_clk_sys_id) and rst_button_sys_n and
-                                                   uart_rstn and wb_ma_pcie_rstn_sync;
+                                                   uart_rstn and '1' when g_BENCH_MODE else wb_ma_pcie_rstn_sync;
   clk_sys_rst_raw                            <= not clk_sys_rstn_raw;
 
   -- Additional stage for clk_sys reset as we AND other resets that might fail

--- a/hdl/rtl/base/afc_base_pkg.vhd
+++ b/hdl/rtl/base/afc_base_pkg.vhd
@@ -29,6 +29,9 @@ package afc_base_pkg is
   --------------------------------------------------------------------
   component afc_base
   generic (
+    -- Bench mode, prevents PCIe reseting devices sharing the
+    -- rst_sys_n_o reset signal
+    g_BENCH_MODE                             : boolean := false;
     -- system PLL parameters
     g_DIVCLK_DIVIDE                          : integer := 5;
     g_CLKBOUT_MULT_F                         : integer := 48;

--- a/hdl/rtl/base/afc_base_pkg.vhd
+++ b/hdl/rtl/base/afc_base_pkg.vhd
@@ -44,6 +44,7 @@ package afc_base_pkg is
     g_CLK3_DIVIDE                            : integer := 4;
     g_CLK3_PHASE                             : real    := 0.0;
     g_SYS_CLOCK_FREQ                         : integer := 100000000;
+    g_UART_MASTER_BAUD                       : integer := 115200;
     -- aux PLL parameters
     g_AUX_CLKIN_PERIOD                       : real    := 14.400;
     g_AUX_DIVCLK_DIVIDE                      : integer := 1;

--- a/hdl/rtl/base_acq/afc_base_acq.vhd
+++ b/hdl/rtl/base_acq/afc_base_acq.vhd
@@ -61,6 +61,7 @@ generic (
   g_CLK3_DIVIDE                              : integer := 4;
   g_CLK3_PHASE                               : real    := 0.0;
   g_SYS_CLOCK_FREQ                           : integer := 100000000;
+  g_UART_MASTER_BAUD                         : integer := 115200;
   -- aux PLL parameters
   g_AUX_CLKIN_PERIOD                         : real    := 14.400;
   g_AUX_DIVCLK_DIVIDE                        : integer := 1;
@@ -442,6 +443,7 @@ begin
       g_CLK3_DIVIDE                            => g_CLK3_DIVIDE,
       g_CLK3_PHASE                             => g_CLK3_PHASE,
       g_SYS_CLOCK_FREQ                         => g_SYS_CLOCK_FREQ,
+      g_UART_MASTER_BAUD                       => g_UART_MASTER_BAUD,
       -- aux PLL parameters
       g_AUX_CLKIN_PERIOD                       => g_AUX_CLKIN_PERIOD,
       g_AUX_DIVCLK_DIVIDE                      => g_AUX_DIVCLK_DIVIDE,

--- a/hdl/rtl/base_acq/afc_base_acq.vhd
+++ b/hdl/rtl/base_acq/afc_base_acq.vhd
@@ -46,6 +46,9 @@ use work.pcie_cntr_axi_pkg.all;
 
 entity afc_base_acq is
 generic (
+  -- Bench mode, prevents PCIe reseting devices sharing the
+  -- rst_sys_n_o reset signal
+  g_BENCH_MODE                               : boolean := false;
   -- system PLL parameters
   g_DIVCLK_DIVIDE                            : integer := 5;
   g_CLKBOUT_MULT_F                           : integer := 48;
@@ -426,6 +429,7 @@ begin
 
   cmp_afc_base : afc_base
     generic map (
+      g_BENCH_MODE                             => g_BENCH_MODE,
       -- system PLL parameters
       g_DIVCLK_DIVIDE                          => g_DIVCLK_DIVIDE,
       g_CLKBOUT_MULT_F                         => g_CLKBOUT_MULT_F,

--- a/hdl/rtl/base_acq/afc_base_acq_pkg.vhd
+++ b/hdl/rtl/base_acq/afc_base_acq_pkg.vhd
@@ -65,6 +65,7 @@ package afc_base_acq_pkg is
     g_CLK3_DIVIDE                              : integer := 4;
     g_CLK3_PHASE                               : real    := 0.0;
     g_SYS_CLOCK_FREQ                           : integer := 100000000;
+    g_UART_MASTER_BAUD                         : integer := 115200;
     -- aux PLL parameters
     g_AUX_CLKIN_PERIOD                         : real    := 14.400;
     g_AUX_DIVCLK_DIVIDE                        : integer := 1;

--- a/hdl/rtl/base_acq/afc_base_acq_pkg.vhd
+++ b/hdl/rtl/base_acq/afc_base_acq_pkg.vhd
@@ -50,6 +50,9 @@ package afc_base_acq_pkg is
   --------------------------------------------------------------------
   component afc_base_acq
   generic (
+    -- Bench mode, prevents PCIe reseting devices sharing the
+    -- rst_sys_n_o reset signal
+    g_BENCH_MODE                               : boolean := false;
     -- system PLL parameters
     g_DIVCLK_DIVIDE                            : integer := 5;
     g_CLKBOUT_MULT_F                           : integer := 48;

--- a/hdl/rtl/wrappers/afc_base_wrapper_pkg.vhd
+++ b/hdl/rtl/wrappers/afc_base_wrapper_pkg.vhd
@@ -21,6 +21,9 @@ package afc_base_wrappers_pkg is
 
   component afcv3_base
   generic (
+    -- Bench mode, prevents PCIe reseting devices sharing the
+    -- rst_sys_n_o reset signal
+    g_BENCH_MODE                             : boolean := false;
     -- system PLL parameters
     g_DIVCLK_DIVIDE                          : integer := 5;
     g_CLKBOUT_MULT_F                         : integer := 48;
@@ -269,6 +272,9 @@ package afc_base_wrappers_pkg is
 
   component afcv4_base
   generic (
+    -- Bench mode, prevents PCIe reseting devices sharing the
+    -- rst_sys_n_o reset signal
+    g_BENCH_MODE                             : boolean := false;
     -- system PLL parameters
     g_DIVCLK_DIVIDE                          : integer := 5;
     g_CLKBOUT_MULT_F                         : integer := 48;
@@ -518,6 +524,9 @@ package afc_base_wrappers_pkg is
 
   component afcv3_base_acq
   generic (
+    -- Bench mode, prevents PCIe reseting devices sharing the
+    -- rst_sys_n_o reset signal
+    g_BENCH_MODE                             : boolean := false;
     -- system PLL parameters
     g_DIVCLK_DIVIDE                            : integer := 5;
     g_CLKBOUT_MULT_F                           : integer := 48;
@@ -764,6 +773,9 @@ package afc_base_wrappers_pkg is
 
   component afcv4_base_acq
   generic (
+    -- Bench mode, prevents PCIe reseting devices sharing the
+    -- rst_sys_n_o reset signal
+    g_BENCH_MODE                               : boolean := false;
     -- system PLL parameters
     g_DIVCLK_DIVIDE                            : integer := 5;
     g_CLKBOUT_MULT_F                           : integer := 48;

--- a/hdl/rtl/wrappers/afc_base_wrapper_pkg.vhd
+++ b/hdl/rtl/wrappers/afc_base_wrapper_pkg.vhd
@@ -36,6 +36,7 @@ package afc_base_wrappers_pkg is
     g_CLK3_DIVIDE                            : integer := 4;
     g_CLK3_PHASE                             : real    := 0.0;
     g_SYS_CLOCK_FREQ                         : integer := 100000000;
+    g_UART_MASTER_BAUD                       : integer := 115200;
     -- aux PLL parameters
     g_AUX_CLKIN_PERIOD                       : real    := 14.400;
     g_AUX_DIVCLK_DIVIDE                      : integer := 1;
@@ -287,6 +288,7 @@ package afc_base_wrappers_pkg is
     g_CLK3_DIVIDE                            : integer := 4;
     g_CLK3_PHASE                             : real    := 0.0;
     g_SYS_CLOCK_FREQ                         : integer := 100000000;
+    g_UART_MASTER_BAUD                       : integer := 115200;
     -- aux PLL parameters
     g_AUX_CLKIN_PERIOD                       : real    := 14.400;
     g_AUX_DIVCLK_DIVIDE                      : integer := 1;
@@ -539,6 +541,7 @@ package afc_base_wrappers_pkg is
     g_CLK3_DIVIDE                              : integer := 4;
     g_CLK3_PHASE                               : real    := 0.0;
     g_SYS_CLOCK_FREQ                           : integer := 100000000;
+    g_UART_MASTER_BAUD                         : integer := 115200;
     -- aux PLL parameters
     g_AUX_CLKIN_PERIOD                       : real    := 14.400;
     g_AUX_DIVCLK_DIVIDE                      : integer := 1;
@@ -788,6 +791,7 @@ package afc_base_wrappers_pkg is
     g_CLK3_DIVIDE                              : integer := 4;
     g_CLK3_PHASE                               : real    := 0.0;
     g_SYS_CLOCK_FREQ                           : integer := 100000000;
+    g_UART_MASTER_BAUD                         : integer := 115200;
     -- aux PLL parameters
     g_AUX_CLKIN_PERIOD                         : real    := 14.400;
     g_AUX_DIVCLK_DIVIDE                        : integer := 1;

--- a/hdl/rtl/wrappers/afcv3_base.vhd
+++ b/hdl/rtl/wrappers/afcv3_base.vhd
@@ -34,6 +34,9 @@ use work.pcie_cntr_axi_pkg.all;
 
 entity afcv3_base is
 generic (
+  -- Bench mode, prevents PCIe reseting devices sharing the
+  -- rst_sys_n_o reset signal
+  g_BENCH_MODE                             : boolean := false;
   -- system PLL parameters
   g_DIVCLK_DIVIDE                          : integer := 5;
   g_CLKBOUT_MULT_F                         : integer := 48;
@@ -286,6 +289,7 @@ begin
 
   cmp_afc_base : afc_base
     generic map (
+      g_BENCH_MODE                             => g_BENCH_MODE,
       -- system PLL parameters
       g_DIVCLK_DIVIDE                          => g_DIVCLK_DIVIDE,
       g_CLKBOUT_MULT_F                         => g_CLKBOUT_MULT_F,

--- a/hdl/rtl/wrappers/afcv3_base.vhd
+++ b/hdl/rtl/wrappers/afcv3_base.vhd
@@ -49,6 +49,7 @@ generic (
   g_CLK3_DIVIDE                            : integer := 4;
   g_CLK3_PHASE                             : real    := 0.0;
   g_SYS_CLOCK_FREQ                         : integer := 100000000;
+  g_UART_MASTER_BAUD                       : integer := 115200;
   -- aux PLL parameters
   g_AUX_CLKIN_PERIOD                       : real    := 14.400;
   g_AUX_DIVCLK_DIVIDE                      : integer := 1;
@@ -302,6 +303,7 @@ begin
       g_CLK3_DIVIDE                            => g_CLK3_DIVIDE,
       g_CLK3_PHASE                             => g_CLK3_PHASE,
       g_SYS_CLOCK_FREQ                         => g_SYS_CLOCK_FREQ,
+      g_UART_MASTER_BAUD                       => g_UART_MASTER_BAUD,
       -- aux PLL parameters
       g_AUX_CLKIN_PERIOD                       => g_AUX_CLKIN_PERIOD,
       g_AUX_DIVCLK_DIVIDE                      => g_AUX_DIVCLK_DIVIDE,

--- a/hdl/rtl/wrappers/afcv3_base_acq.vhd
+++ b/hdl/rtl/wrappers/afcv3_base_acq.vhd
@@ -36,6 +36,9 @@ use work.afc_base_acq_pkg.all;
 
 entity afcv3_base_acq is
 generic (
+  -- Bench mode, prevents PCIe reseting devices sharing the
+  -- rst_sys_n_o reset signal
+  g_BENCH_MODE                               : boolean := false;
   -- system PLL parameters
   g_DIVCLK_DIVIDE                            : integer := 5;
   g_CLKBOUT_MULT_F                           : integer := 48;
@@ -286,6 +289,7 @@ begin
 
   cmp_afc_base_acq : afc_base_acq
     generic map (
+      g_BENCH_MODE                             => g_BENCH_MODE,
       g_DIVCLK_DIVIDE                          => g_DIVCLK_DIVIDE,
       g_CLKBOUT_MULT_F                         => g_CLKBOUT_MULT_F,
       g_CLK0_DIVIDE_F                          => g_CLK0_DIVIDE_F,

--- a/hdl/rtl/wrappers/afcv3_base_acq.vhd
+++ b/hdl/rtl/wrappers/afcv3_base_acq.vhd
@@ -51,6 +51,7 @@ generic (
   g_CLK3_DIVIDE                              : integer := 4;
   g_CLK3_PHASE                               : real    := 0.0;
   g_SYS_CLOCK_FREQ                           : integer := 100000000;
+  g_UART_MASTER_BAUD                         : integer := 115200;
   -- aux PLL parameters
   g_AUX_CLKIN_PERIOD                         : real    := 14.400;
   g_AUX_DIVCLK_DIVIDE                        : integer := 1;
@@ -296,6 +297,7 @@ begin
       g_CLK1_DIVIDE                            => g_CLK1_DIVIDE,
       g_CLK2_DIVIDE                            => g_CLK2_DIVIDE,
       g_SYS_CLOCK_FREQ                         => g_SYS_CLOCK_FREQ,
+      g_UART_MASTER_BAUD                       => g_UART_MASTER_BAUD,
       -- aux PLL parameters
       g_AUX_CLKIN_PERIOD                       => g_AUX_CLKIN_PERIOD,
       g_AUX_DIVCLK_DIVIDE                      => g_AUX_DIVCLK_DIVIDE,

--- a/hdl/rtl/wrappers/afcv4_base.vhd
+++ b/hdl/rtl/wrappers/afcv4_base.vhd
@@ -49,6 +49,7 @@ generic (
   g_CLK3_DIVIDE                            : integer := 4;
   g_CLK3_PHASE                             : real    := 0.0;
   g_SYS_CLOCK_FREQ                         : integer := 100000000;
+  g_UART_MASTER_BAUD                       : integer := 115200;
   -- aux PLL parameters
   g_AUX_CLKIN_PERIOD                       : real    := 14.400;
   g_AUX_DIVCLK_DIVIDE                      : integer := 1;
@@ -303,6 +304,7 @@ begin
       g_CLK3_DIVIDE                            => g_CLK3_DIVIDE,
       g_CLK3_PHASE                             => g_CLK3_PHASE,
       g_SYS_CLOCK_FREQ                         => g_SYS_CLOCK_FREQ,
+      g_UART_MASTER_BAUD                       => g_UART_MASTER_BAUD,
       -- aux PLL parameters
       g_AUX_CLKIN_PERIOD                       => g_AUX_CLKIN_PERIOD,
       g_AUX_DIVCLK_DIVIDE                      => g_AUX_DIVCLK_DIVIDE,

--- a/hdl/rtl/wrappers/afcv4_base.vhd
+++ b/hdl/rtl/wrappers/afcv4_base.vhd
@@ -34,6 +34,9 @@ use work.pcie_cntr_axi_pkg.all;
 
 entity afcv4_base is
 generic (
+  -- Bench mode, prevents PCIe reseting devices sharing the
+  -- rst_sys_n_o reset signal
+  g_BENCH_MODE                             : boolean := false;
   -- system PLL parameters
   g_DIVCLK_DIVIDE                          : integer := 5;
   g_CLKBOUT_MULT_F                         : integer := 48;
@@ -287,6 +290,7 @@ begin
 
   cmp_afc_base : afc_base
     generic map (
+      g_BENCH_MODE                             => g_BENCH_MODE,
       -- system PLL parameters
       g_DIVCLK_DIVIDE                          => g_DIVCLK_DIVIDE,
       g_CLKBOUT_MULT_F                         => g_CLKBOUT_MULT_F,

--- a/hdl/rtl/wrappers/afcv4_base_acq.vhd
+++ b/hdl/rtl/wrappers/afcv4_base_acq.vhd
@@ -51,6 +51,7 @@ generic (
   g_CLK3_DIVIDE                              : integer := 4;
   g_CLK3_PHASE                               : real    := 0.0;
   g_SYS_CLOCK_FREQ                           : integer := 100000000;
+  g_UART_MASTER_BAUD                         : integer := 115200;
   -- aux PLL parameters
   g_AUX_CLKIN_PERIOD                         : real    := 14.400;
   g_AUX_DIVCLK_DIVIDE                        : integer := 1;
@@ -297,6 +298,7 @@ begin
       g_CLK1_DIVIDE                            => g_CLK1_DIVIDE,
       g_CLK2_DIVIDE                            => g_CLK2_DIVIDE,
       g_SYS_CLOCK_FREQ                         => g_SYS_CLOCK_FREQ,
+      g_UART_MASTER_BAUD                       => g_UART_MASTER_BAUD,
       -- aux PLL parameters
       g_AUX_CLKIN_PERIOD                       => g_AUX_CLKIN_PERIOD,
       g_AUX_DIVCLK_DIVIDE                      => g_AUX_DIVCLK_DIVIDE,

--- a/hdl/rtl/wrappers/afcv4_base_acq.vhd
+++ b/hdl/rtl/wrappers/afcv4_base_acq.vhd
@@ -36,6 +36,9 @@ use work.afc_base_acq_pkg.all;
 
 entity afcv4_base_acq is
 generic (
+  -- Bench mode, prevents PCIe reseting devices sharing the
+  -- rst_sys_n_o reset signal
+  g_BENCH_MODE                               : boolean := false;
   -- system PLL parameters
   g_DIVCLK_DIVIDE                            : integer := 5;
   g_CLKBOUT_MULT_F                           : integer := 48;
@@ -287,6 +290,7 @@ begin
 
   cmp_afc_base_acq : afc_base_acq
     generic map (
+      g_BENCH_MODE                             => g_BENCH_MODE,
       g_DIVCLK_DIVIDE                          => g_DIVCLK_DIVIDE,
       g_CLKBOUT_MULT_F                         => g_CLKBOUT_MULT_F,
       g_CLK0_DIVIDE_F                          => g_CLK0_DIVIDE_F,

--- a/hdl/syn/afc_v3/vivado/acq/Manifest.py
+++ b/hdl/syn/afc_v3/vivado/acq/Manifest.py
@@ -30,10 +30,15 @@ board = "afc"
 # For appending  the afc_acq.xdc to synthesis
 afc_base_xdc = ['acq']
 
+files = []
+
+# TCL commands file
+files.append("commands.tcl")
+
 import os
 import sys
 if os.path.isfile("synthesis_descriptor_pkg.vhd"):
-    files = ["synthesis_descriptor_pkg.vhd"];
+    files.append("synthesis_descriptor_pkg.vhd");
 else:
     sys.exit("Generate the SDB descriptor before using HDLMake (./build_synthesis_sdb.sh)")
 

--- a/hdl/syn/afc_v3/vivado/acq/commands.tcl
+++ b/hdl/syn/afc_v3/vivado/acq/commands.tcl
@@ -1,0 +1,2 @@
+puts "Setting all VHDL source files file_type to VHDL 2008"
+set_property file_type {VHDL 2008} [get_files -filter {FILE_TYPE == VHDL}]

--- a/hdl/syn/afc_v3/vivado/full/Manifest.py
+++ b/hdl/syn/afc_v3/vivado/full/Manifest.py
@@ -27,10 +27,15 @@ syn_properties = [
 
 board = "afc"
 
+files = []
+
+# TCL commands file
+files.append("commands.tcl")
+
 import os
 import sys
 if os.path.isfile("synthesis_descriptor_pkg.vhd"):
-    files = ["synthesis_descriptor_pkg.vhd"];
+    files.append("synthesis_descriptor_pkg.vhd");
 else:
     sys.exit("Generate the SDB descriptor before using HDLMake (./build_synthesis_sdb.sh)")
 

--- a/hdl/syn/afc_v3/vivado/full/commands.tcl
+++ b/hdl/syn/afc_v3/vivado/full/commands.tcl
@@ -1,0 +1,2 @@
+puts "Setting all VHDL source files file_type to VHDL 2008"
+set_property file_type {VHDL 2008} [get_files -filter {FILE_TYPE == VHDL}]

--- a/hdl/syn/afc_v3/vivado/pcie_leds/Manifest.py
+++ b/hdl/syn/afc_v3/vivado/pcie_leds/Manifest.py
@@ -27,10 +27,15 @@ syn_properties = [
 
 board = "afc"
 
+files = []
+
+# TCL commands file
+files.append("commands.tcl")
+
 import os
 import sys
 if os.path.isfile("synthesis_descriptor_pkg.vhd"):
-    files = ["synthesis_descriptor_pkg.vhd"];
+    files.append("synthesis_descriptor_pkg.vhd");
 else:
     sys.exit("Generate the SDB descriptor before using HDLMake (./build_synthesis_sdb.sh)")
 

--- a/hdl/syn/afc_v3/vivado/pcie_leds/commands.tcl
+++ b/hdl/syn/afc_v3/vivado/pcie_leds/commands.tcl
@@ -1,0 +1,2 @@
+puts "Setting all VHDL source files file_type to VHDL 2008"
+set_property file_type {VHDL 2008} [get_files -filter {FILE_TYPE == VHDL}]

--- a/hdl/top/afc_v3/vivado/acq/afc_acq.vhd
+++ b/hdl/top/afc_v3/vivado/acq/afc_acq.vhd
@@ -298,6 +298,7 @@ begin
 
   cmp_afc_base_acq : afc_base_acq
     generic map (
+      g_BENCH_MODE                             => false,
       --  If true, instantiate a VIC/UART/SPI.
       g_WITH_VIC                               => true,
       g_WITH_UART_MASTER                       => true,

--- a/hdl/top/afc_v3/vivado/acq/afc_acq.vhd
+++ b/hdl/top/afc_v3/vivado/acq/afc_acq.vhd
@@ -302,6 +302,7 @@ begin
       --  If true, instantiate a VIC/UART/SPI.
       g_WITH_VIC                               => true,
       g_WITH_UART_MASTER                       => true,
+      g_UART_MASTER_BAUD                       => 115200,
       g_WITH_TRIGGER                           => true,
       g_WITH_SPI                               => false,
       g_WITH_BOARD_I2C                         => true,

--- a/hdl/top/afc_v3/vivado/full/afc_full.vhd
+++ b/hdl/top/afc_v3/vivado/full/afc_full.vhd
@@ -206,6 +206,7 @@ begin
 
   cmp_afc_base : afc_base
     generic map (
+      g_BENCH_MODE                             => false,
       --  If true, instantiate a VIC/UART/SPI.
       g_WITH_VIC                               => true,
       g_WITH_UART_MASTER                       => true,

--- a/hdl/top/afc_v3/vivado/full/afc_full.vhd
+++ b/hdl/top/afc_v3/vivado/full/afc_full.vhd
@@ -210,6 +210,7 @@ begin
       --  If true, instantiate a VIC/UART/SPI.
       g_WITH_VIC                               => true,
       g_WITH_UART_MASTER                       => true,
+      g_UART_MASTER_BAUD                       => 115200,
       g_WITH_TRIGGER                           => true,
       g_WITH_SPI                               => false,
       g_WITH_BOARD_I2C                         => true,

--- a/hdl/top/afc_v3/vivado/pcie_leds/pcie_leds.vhd
+++ b/hdl/top/afc_v3/vivado/pcie_leds/pcie_leds.vhd
@@ -155,6 +155,7 @@ begin
 
   cmp_afc_base : afc_base
     generic map (
+      g_BENCH_MODE                             => false,
       --  If true, instantiate a VIC/UART/SPI.
       g_WITH_VIC                               => false,
       g_WITH_UART_MASTER                       => false,

--- a/hdl/top/afc_v3/vivado/pcie_leds/pcie_leds.vhd
+++ b/hdl/top/afc_v3/vivado/pcie_leds/pcie_leds.vhd
@@ -159,6 +159,7 @@ begin
       --  If true, instantiate a VIC/UART/SPI.
       g_WITH_VIC                               => false,
       g_WITH_UART_MASTER                       => false,
+      g_UART_MASTER_BAUD                       => 115200,
       g_WITH_TRIGGER                           => false,
       g_WITH_SPI                               => false,
       g_WITH_BOARD_I2C                         => false,


### PR DESCRIPTION
The `xwb_rs232_syscon` core is not tailored to be controlled via software (it expects an VT100 compatible terminal and direct user interaction) and seems to have some bug that leads to random hangs. I've replaced it with a much simpler implementation that works reliably.